### PR TITLE
Potential fix for code scanning alert no. 24: Uncontrolled data used in path expression

### DIFF
--- a/Controllers/VulnerableController.cs
+++ b/Controllers/VulnerableController.cs
@@ -54,8 +54,18 @@ namespace ShipServicesApp.Controllers
         [HttpGet("download")]
         public IActionResult DownloadFile(string filename)
         {
-            // Vulnerable: No path validation
-            var filePath = $"/var/www/files/{filename}";
+            // Validate and normalize the requested file path to prevent path traversal
+            var baseDirectory = "/var/www/files";
+            var baseDirectoryFullPath = System.IO.Path.GetFullPath(baseDirectory);
+            var combinedPath = System.IO.Path.Combine(baseDirectoryFullPath, filename ?? string.Empty);
+            var filePath = System.IO.Path.GetFullPath(combinedPath);
+
+            // Ensure the resolved path is still within the intended base directory
+            if (!filePath.StartsWith(baseDirectoryFullPath + System.IO.Path.DirectorySeparatorChar))
+            {
+                return BadRequest("Invalid file path.");
+            }
+
             if (System.IO.File.Exists(filePath))
             {
                 var fileBytes = System.IO.File.ReadAllBytes(filePath);


### PR DESCRIPTION
Potential fix for [https://github.com/xebia/ShipServiceApp/security/code-scanning/24](https://github.com/xebia/ShipServiceApp/security/code-scanning/24)

In general, to fix uncontrolled path usage, you must ensure that user input cannot cause the application to read or write outside an intended directory. This is typically done by combining the user input with a trusted base directory, resolving the combined path to its canonical form, and then checking that the resolved path is still inside the base directory. Alternatively, if the input should be just a simple filename, you can reject any input that contains path separators or `..`.

For this endpoint, the intent is clearly to only serve files from `/var/www/files/`. The minimal change that preserves existing behavior is to (1) define a base directory, (2) safely combine it with `filename` using `Path.Combine`, (3) canonicalize the resulting path with `Path.GetFullPath`, and (4) verify that the canonical path starts with the canonical base directory plus a directory separator; if not, return `BadRequest`. This prevents traversal using `..` or absolute paths while still allowing all legitimate filenames that live under the base directory.

Concretely in `Controllers/VulnerableController.cs`, inside `DownloadFile` we will:
- Introduce a `baseDirectory` string set to `"/var/www/files"`.
- Use `System.IO.Path.Combine(baseDirectory, filename)` and then `System.IO.Path.GetFullPath(...)` to obtain `filePath`.
- Compute `baseDirectoryFullPath = System.IO.Path.GetFullPath(baseDirectory)` and check `filePath.StartsWith(baseDirectoryFullPath + System.IO.Path.DirectorySeparatorChar)`. If this fails, return `BadRequest("Invalid file path.")`.
- Keep the rest of the logic (existence check, read bytes, and return as download) unchanged.

We do not need any new `using` statements because we already refer to `System.IO.File` fully qualified, and we can similarly call `System.IO.Path` fully qualified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
